### PR TITLE
Sending k8s events to helm-cli

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -75,7 +75,7 @@ type ResourceActorFunc func(*resource.Info) error
 // Create creates kubernetes resources from an io.reader
 //
 // Namespace will set the namespace
-func (c *Client) Create(namespace string, reader io.Reader, timeout int64, shouldWait bool) error {
+func (c *Client) Create(namespace string, reader io.Reader, writer io.Writer, timeout int64, shouldWait bool) error {
 	client, err := c.ClientSet()
 	if err != nil {
 		return err
@@ -91,7 +91,7 @@ func (c *Client) Create(namespace string, reader io.Reader, timeout int64, shoul
 		return err
 	}
 	if shouldWait {
-		return c.waitForResources(time.Duration(timeout)*time.Second, infos)
+		return c.waitForResources(time.Duration(timeout)*time.Second, infos, writer)
 	}
 	return nil
 }
@@ -208,7 +208,7 @@ func (c *Client) Get(namespace string, reader io.Reader) (string, error) {
 //  not present in the target configuration
 //
 // Namespace will set the namespaces
-func (c *Client) Update(namespace string, originalReader, targetReader io.Reader, recreate bool, timeout int64, shouldWait bool) error {
+func (c *Client) Update(namespace string, originalReader, targetReader io.Reader, writer io.Writer, recreate bool, timeout int64, shouldWait bool) error {
 	original, err := c.BuildUnstructured(namespace, originalReader)
 	if err != nil {
 		return fmt.Errorf("failed decoding reader into objects: %s", err)
@@ -269,7 +269,7 @@ func (c *Client) Update(namespace string, originalReader, targetReader io.Reader
 		}
 	}
 	if shouldWait {
-		return c.waitForResources(time.Duration(timeout)*time.Second, target)
+		return c.waitForResources(time.Duration(timeout)*time.Second, target, writer)
 	}
 	return nil
 }

--- a/pkg/releasetesting/environment.go
+++ b/pkg/releasetesting/environment.go
@@ -39,7 +39,8 @@ type Environment struct {
 
 func (env *Environment) createTestPod(test *test) error {
 	b := bytes.NewBufferString(test.manifest)
-	if err := env.KubeClient.Create(env.Namespace, b, env.Timeout, false); err != nil {
+	eventsLog := bytes.NewBuffer(nil)
+	if err := env.KubeClient.Create(env.Namespace, b, eventsLog, env.Timeout, false); err != nil {
 		log.Printf(err.Error())
 		test.result.Info = err.Error()
 		test.result.Status = release.TestRun_FAILURE

--- a/pkg/tiller/environment/environment.go
+++ b/pkg/tiller/environment/environment.go
@@ -114,7 +114,7 @@ type KubeClient interface {
 	//
 	// reader must contain a YAML stream (one or more YAML documents separated
 	// by "\n---\n").
-	Create(namespace string, reader io.Reader, timeout int64, shouldWait bool) error
+	Create(namespace string, reader io.Reader, writer io.Writer, timeout int64, shouldWait bool) error
 
 	// Get gets one or more resources. Returned string hsa the format like kubectl
 	// provides with the column headers separating the resource types.
@@ -147,7 +147,7 @@ type KubeClient interface {
 	//
 	// reader must contain a YAML stream (one or more YAML documents separated
 	// by "\n---\n").
-	Update(namespace string, originalReader, modifiedReader io.Reader, recreate bool, timeout int64, shouldWait bool) error
+	Update(namespace string, originalReader, modifiedReader io.Reader, writer io.Writer, recreate bool, timeout int64, shouldWait bool) error
 
 	Build(namespace string, reader io.Reader) (kube.Result, error)
 	BuildUnstructured(namespace string, reader io.Reader) (kube.Result, error)


### PR DESCRIPTION
Hi
This patchest implements sending k8s events to helm-cli.
Sending works synchronously and did not use any additional gRPC calls:
responses from k8s cluster aggregates in buffer on tiller side whole time
while waiting reponse for install/update operation,
and then pass them to helm client as error, providing all information of any k8s-resources.
So, that information may be useful, especially in case of using helm/tiller in CI/CD systems
(this my use-case)

 Example:
```
$ ./bin/helm install --wait --timeout 10 stable/mysql
Error:
Tiller log:
[2017/05/03 15:22:32] [PVC] [Type]: Warning [Reason]: ProvisioningFailed [Message]: cannot find volume plugin for alpha provisioning
[2017/05/03 15:22:32] [Deployment] [Type]: Normal [Reason]: ScalingReplicaSet [Message]: Scaled up replica set orange-seastar-mysql-1708821563 to 1
[2017/05/03 15:22:34] [PVC] [Type]: Warning [Reason]: ProvisioningFailed [Message]: cannot find volume plugin for alpha provisioning
[2017/05/03 15:22:34] [Deployment] [Type]: Normal [Reason]: ScalingReplicaSet [Message]: Scaled up replica set orange-seastar-mysql-1708821563 to 1
[2017/05/03 15:22:36] [PVC] [Type]: Warning [Reason]: ProvisioningFailed [Message]: cannot find volume plugin for alpha provisioning
[2017/05/03 15:22:36] [Deployment] [Type]: Normal [Reason]: ScalingReplicaSet [Message]: Scaled up replica set orange-seastar-mysql-1708821563 to 1
[2017/05/03 15:22:38] [PVC] [Type]: Warning [Reason]: ProvisioningFailed [Message]: cannot find volume plugin for alpha provisioning
[2017/05/03 15:22:38] [Deployment] [Type]: Normal [Reason]: ScalingReplicaSet [Message]: Scaled up replica set orange-seastar-mysql-1708821563 to 1
[2017/05/03 15:22:40] [PVC] [Type]: Warning [Reason]: ProvisioningFailed [Message]: cannot find volume plugin for alpha provisioning
[2017/05/03 15:22:40] [Deployment] [Type]: Normal [Reason]: ScalingReplicaSet [Message]: Scaled up replica set orange-seastar-mysql-1708821563 to 1
[2017/05/03 15:22:40] [PVC] [Type]: Warning [Reason]: ProvisioningFailed [Message]: cannot find volume plugin for alpha provisioning
[2017/05/03 15:22:40] [Deployment] [Type]: Normal [Reason]: ScalingReplicaSet [Message]: Scaled up replica set orange-seastar-mysql-1708821563 to 1

release orange-seastar failed: timed out waiting for the condition
```

If its looks reasonable
Thanks in advance!